### PR TITLE
Add coloring support for mem regions defined in the project config

### DIFF
--- a/src/core/inc/platform.h
+++ b/src/core/inc/platform.h
@@ -26,6 +26,8 @@ struct mem_region {
 
     int place_phys;
     uint64_t phys;
+
+    int colored;
 };
 
 struct dev_region {

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -113,6 +113,8 @@ void vm_map_mem_region(vm_t* vm, struct mem_region* reg)
 
     if (reg->place_phys) {
         ppages_t pa_reg = mem_ppages_get(reg->phys, n);
+        if(reg->colored)
+            pa_reg.colors = vm->as.colors;
         mem_map(&vm->as, va, &pa_reg, n, PTE_VM_FLAGS);
     } else {
         mem_map(&vm->as, va, NULL, n, PTE_VM_FLAGS);


### PR DESCRIPTION
Allows coloring of physically placed memory regions by setting a flag in the configuration (mem_region.colored).